### PR TITLE
Weapon fixes | Checks added | Various things

### DIFF
--- a/lua/lambdaplayers/lambda/sv_weaponhandling.lua
+++ b/lua/lambdaplayers/lambda/sv_weaponhandling.lua
@@ -71,7 +71,7 @@ local function DefaultRangedWeaponFire( self, wepent, target, weapondata, disabl
     if !disabletbl.sound then wepent:EmitSound( TranslateRandomization( weapondata.attacksnd ), 70, 100, 1, CHAN_WEAPON ) end
     
     if !disabletbl.muzzleflash then self:HandleMuzzleFlash( weapondata.muzzleflash ) end
-    if !disabletbl.shell then self:HandleShellEject( weapondata.shelleject ) end
+    if !disabletbl.shell then self:HandleShellEject( weapondata.shelleject, weapondata.shelloffpos, weapondata.shelloffang ) end
 
     if !disabletbl.anim then
         self:RemoveGesture( weapondata.attackanim )
@@ -84,8 +84,8 @@ local function DefaultRangedWeaponFire( self, wepent, target, weapondata, disabl
         bullettbl.Damage = weapondata.damage
         bullettbl.Force = weapondata.damage
         bullettbl.HullSize = 5
-        bullettbl.Num = 1
-        bullettbl.TracerName = "Tracer"
+        bullettbl.Num = weapondata.bulletcount or 1
+        bullettbl.TracerName = weapondata.tracername or "Tracer"
         bullettbl.Dir = ( target:WorldSpaceCenter() - wepent:GetPos() ):GetNormalized()
         bullettbl.Src = wepent:GetPos()
         bullettbl.Spread = Vector( weapondata.spread, weapondata.spread, 0 )
@@ -156,9 +156,9 @@ function ENT:ReloadWeapon()
     self:SetIsReloading( true )
 
     local wep = self:GetWeaponENT()
-    local time = weapondata.reloadtime
-    local anim = weapondata.reloadanim
-    local animspeed = weapondata.reloadanimationspeed
+    local time = weapondata.reloadtime or 1
+    local anim = weapondata.reloadanim or ACT_HL2MP_GESTURE_RELOAD_PISTOL
+    local animspeed = weapondata.reloadanimationspeed or 1
     local snds = weapondata.reloadsounds
 
     if snds and #snds > 0 then

--- a/lua/lambdaplayers/lambda/sv_weaponhandling.lua
+++ b/lua/lambdaplayers/lambda/sv_weaponhandling.lua
@@ -157,7 +157,7 @@ function ENT:ReloadWeapon()
 
     local wep = self:GetWeaponENT()
     local time = weapondata.reloadtime or 1
-    local anim = weapondata.reloadanim or ACT_HL2MP_GESTURE_RELOAD_PISTOL
+    local anim = weapondata.reloadanim
     local animspeed = weapondata.reloadanimationspeed or 1
     local snds = weapondata.reloadsounds
 
@@ -169,8 +169,10 @@ function ENT:ReloadWeapon()
         end
     end
 
-    local id = self:AddGesture( anim )
-    self:SetLayerPlaybackRate( id, animspeed )
+    if anim then
+        local id = self:AddGesture( anim )
+        self:SetLayerPlaybackRate( id, animspeed )
+    end
 
     self:NamedTimer( "Reload", time, 1, function()
         if !self:GetIsReloading() then return end

--- a/lua/lambdaplayers/lambda/weapons/hl2_ar2.lua
+++ b/lua/lambdaplayers/lambda/weapons/hl2_ar2.lua
@@ -1,8 +1,8 @@
 local CurTime = CurTime
 local random = math.random
-local inertionVec = Vector( 500, 500, 500 )
 local ballMass = GetConVar( "sk_weapon_ar2_alt_fire_mass" )
 local ballRadius = GetConVar( "sk_weapon_ar2_alt_fire_radius" )
+local ballTime = GetConVar( "sk_weapon_ar2_alt_fire_duration" )
 
 table.Merge( _LAMBDAPLAYERSWEAPONS, {
 
@@ -20,7 +20,7 @@ table.Merge( _LAMBDAPLAYERSWEAPONS, {
         damage = 8,
         spread = 0.1,
         rateoffire = 0.10,
-        muzzleflash = 1,
+        muzzleflash = 5,
         shelleject = "none",
         attackanim = ACT_HL2MP_GESTURE_RANGE_ATTACK_AR2,
         attacksnd = "Weapon_AR2.Single",
@@ -42,35 +42,36 @@ table.Merge( _LAMBDAPLAYERSWEAPONS, {
                 wepent:EmitSound( "Weapon_CombineGuard.Special1" )
 
                 self:SimpleTimer( 0.75, function()
-                    local comBall = ents.Create( "prop_combine_ball" )
-                    if IsValid( comBall ) then 
-                        wepent:StopSound( "Weapon_CombineGuard.Special1" )
-                        wepent:EmitSound( "Weapon_IRifle.Single" )
+                    if IsValid( wepent ) then
+                        local comBall = ents.Create( "prop_combine_ball" )
+                        if IsValid( comBall ) then 
+                            wepent:EmitSound( "Weapon_IRifle.Single" )
 
-                        self:AddGesture( ACT_HL2MP_GESTURE_RANGE_ATTACK_CROSSBOW )
+                            self:AddGesture( ACT_HL2MP_GESTURE_RANGE_ATTACK_CROSSBOW )
 
-                        local launchAng = ( IsValid( target ) and ( target:WorldSpaceCenter() - self:EyePos() ):Angle() or self:GetAngles() )
-                        local launchVel = ( launchAng:Forward() * 1000 )
-                        
-                        comBall:SetSaveValue( "m_flRadius", ballRadius:GetFloat() )
-                        comBall:SetPos( self:EyePos() + launchAng:Forward() * 32 )
-                        comBall:SetOwner( self )
-                        comBall:Spawn()
-                        comBall:SetSaveValue( "m_nState", 2 )
-                        comBall:SetSaveValue( "m_flSpeed", launchVel:Length() )
+                            local launchAng = ( IsValid( target ) and ( target:WorldSpaceCenter() - self:EyePos() ):Angle() or self:GetAngles() )
+                            local launchVel = ( launchAng:Forward() * 1000 )
+                            
+                            comBall:SetSaveValue( "m_flRadius", ballRadius:GetFloat() )
+                            comBall:SetPos( self:EyePos() + launchAng:Forward() * 32 + launchAng:Up() * 32 )
+                            comBall:SetOwner( self )
+                            comBall:Spawn()
+                            comBall:SetSaveValue( "m_nState", 2 )
+                            comBall:SetSaveValue( "m_flSpeed", launchVel:Length() )
+                            comBall:Fire( "Explode", nil, ballTime:GetInt() )
 
-                        local phys = comBall:GetPhysicsObject()
-                        if IsValid( phys ) then
-                            phys:SetVelocity( launchVel )
-                            phys:AddGameFlag( FVPHYSICS_WAS_THROWN )
+                            local phys = comBall:GetPhysicsObject()
+                            if IsValid( phys ) then
+                                phys:SetVelocity( launchVel )
+                                phys:AddGameFlag( FVPHYSICS_WAS_THROWN )
 
-                            phys:SetMass( ballMass:GetFloat() )
-                            phys:SetInertia( inertionVec )
+                                phys:SetMass( ballMass:GetFloat() )
+                                phys:SetInertia( Vector( 500, 500, 500 ) )
+                            end
                         end
                     end
-
                 end)
-
+                
                 return true
             end
         end

--- a/lua/lambdaplayers/lambda/weapons/hl2_crossbow.lua
+++ b/lua/lambdaplayers/lambda/weapons/hl2_crossbow.lua
@@ -1,5 +1,4 @@
 local CurTime = CurTime
-local random = math.random
 local boltDmg = GetConVar("sk_plr_dmg_crossbow")
 
 table.Merge( _LAMBDAPLAYERSWEAPONS, {
@@ -16,26 +15,26 @@ table.Merge( _LAMBDAPLAYERSWEAPONS, {
         clip = 1,
 
         reloadtime = 1.83,
-        reloadanimationspeed = 1,
         reloadsounds = { 
             { 0.93, "Weapon_Crossbow.BoltElectrify" }
         },
 
         callback = function( self, wepent, target )
             if self.l_Clip <= 0 then self:ReloadWeapon() return end
+
+            self:RemoveGesture( ACT_HL2MP_GESTURE_RANGE_ATTACK_CROSSBOW )
+            self:AddGesture( ACT_HL2MP_GESTURE_RANGE_ATTACK_CROSSBOW )
             
             local bolt = ents.Create( "crossbow_bolt" )
             if IsValid( bolt ) then
                 self.l_Clip = self.l_Clip - 1
                 self.l_WeaponUseCooldown = CurTime() + 0.4
-                self:RemoveGesture( ACT_HL2MP_GESTURE_RANGE_ATTACK_CROSSBOW )
-                self:AddGesture( ACT_HL2MP_GESTURE_RANGE_ATTACK_CROSSBOW )
 
                 wepent:EmitSound( "Weapon_Crossbow.Single" )
 
                 local fireDir = ( target:WorldSpaceCenter() - self:EyePos() ):Angle()
 
-                bolt:SetPos( self:EyePos() + fireDir:Forward() * 32 ) 
+                bolt:SetPos( self:EyePos() + fireDir:Forward() * 32 + fireDir:Up() * 32 ) 
                 bolt:SetAngles( fireDir )
                 bolt:Spawn()
                 bolt:SetOwner( self )

--- a/lua/lambdaplayers/lambda/weapons/hl2_crossbow.lua
+++ b/lua/lambdaplayers/lambda/weapons/hl2_crossbow.lua
@@ -21,14 +21,14 @@ table.Merge( _LAMBDAPLAYERSWEAPONS, {
 
         callback = function( self, wepent, target )
             if self.l_Clip <= 0 then self:ReloadWeapon() return end
-
-            self:RemoveGesture( ACT_HL2MP_GESTURE_RANGE_ATTACK_CROSSBOW )
-            self:AddGesture( ACT_HL2MP_GESTURE_RANGE_ATTACK_CROSSBOW )
             
             local bolt = ents.Create( "crossbow_bolt" )
             if IsValid( bolt ) then
                 self.l_Clip = self.l_Clip - 1
                 self.l_WeaponUseCooldown = CurTime() + 0.4
+
+                self:RemoveGesture( ACT_HL2MP_GESTURE_RANGE_ATTACK_CROSSBOW )
+                self:AddGesture( ACT_HL2MP_GESTURE_RANGE_ATTACK_CROSSBOW )
 
                 wepent:EmitSound( "Weapon_Crossbow.Single" )
 

--- a/lua/lambdaplayers/lambda/weapons/hl2_grenade.lua
+++ b/lua/lambdaplayers/lambda/weapons/hl2_grenade.lua
@@ -9,20 +9,11 @@ table.Merge( _LAMBDAPLAYERSWEAPONS, {
         prettyname = "Grenade",
         holdtype = "grenade",
         bonemerge = true,
-        keepdistance = 450,
+        keepdistance = 500,
         attackrange = 1000,
-
-        clip = 1,
-
-        reloadtime = 1.5,
-        reloadanim = ACT_HL2MP_GESTURE_RELOAD_PISTOL,
-        reloadanimationspeed = 1,
-        reloadsounds = { },
-
+        
         callback = function( self, wepent, target )
-            if self.l_Clip <= 0 then self:ReloadWeapon() return end-- Just in case
-
-            self.l_WeaponUseCooldown = CurTime() + 1.5
+            self.l_WeaponUseCooldown = CurTime() + 1.8
 
             self:RemoveGesture( ACT_HL2MP_GESTURE_RANGE_ATTACK_GRENADE )
             self:AddGesture( ACT_HL2MP_GESTURE_RANGE_ATTACK_GRENADE )
@@ -30,9 +21,9 @@ table.Merge( _LAMBDAPLAYERSWEAPONS, {
             local throwforce = 1200
             local normal = self:GetForward()
 
-            wepent:EmitSound( "weapons/slam/throw.wav", 70, 100, 1, CHAN_WEAPON )
+            wepent:EmitSound( "Weapon_SLAM.SatchelThrow" )
 
-            if IsValid( target ) and self:GetRangeSquaredTo( target ) < (400 * 400) then
+            if IsValid( target ) and self:GetRangeSquaredTo( target ) < (350 * 350) then
                 throwforce = 400
             end
             if IsValid( target ) then
@@ -40,7 +31,7 @@ table.Merge( _LAMBDAPLAYERSWEAPONS, {
             end
 
             local grenade = ents.Create( "npc_grenade_frag" )
-            grenade:SetPos( self:GetPos() + Vector(0,0,60) + self:GetForward() * 40 + self:GetRight() * -10 )
+            grenade:SetPos( self:GetPos() + Vector(0,0,60) + self:GetForward() * 20 + self:GetRight() * -10 )
             grenade:Fire( "SetTimer", 3, 0 )
             grenade:SetSaveValue( "m_hThrower", self )
             grenade:SetOwner( self )
@@ -49,7 +40,7 @@ table.Merge( _LAMBDAPLAYERSWEAPONS, {
             local frag = grenade:GetPhysicsObject()
             if IsValid( frag ) then
                 frag:ApplyForceCenter( normal * throwforce )
-                frag:AddAngleVelocity( Vector(200,random(-600,600),0) )
+                frag:AddAngleVelocity( Vector(600,random(-1200,1200),0) )
             end
             
             return true

--- a/lua/lambdaplayers/lambda/weapons/hl2_revolver.lua
+++ b/lua/lambdaplayers/lambda/weapons/hl2_revolver.lua
@@ -23,10 +23,10 @@ table.Merge( _LAMBDAPLAYERSWEAPONS, {
         reloadanim = ACT_HL2MP_GESTURE_RELOAD_REVOLVER,
         reloadanimationspeed = 1,
         reloadsounds = { 
-            { 0, "weapons/357/357_reload1.wav" }, 
-            { 0.4, "weapons/357/357_reload4.wav" }, 
-            { 1.5, "weapons/357/357_reload3.wav" }, 
-            { 2.2, "weapons/357/357_spin1.wav" } 
+            { 0, "Weapon_357.OpenLoader" }, 
+            { 0.4, "Weapon_357.RemoveLoader" }, 
+            { 1.5, "Weapon_357.ReplaceLoader" }, 
+            { 2.2, "Weapon_357.Spin" } 
         },
 
         islethal = true,

--- a/lua/lambdaplayers/lambda/weapons/hl2_rpg.lua
+++ b/lua/lambdaplayers/lambda/weapons/hl2_rpg.lua
@@ -1,5 +1,4 @@
 local CurTime = CurTime
-local random = math.random
 
 table.Merge( _LAMBDAPLAYERSWEAPONS, {
 --Missing guided rockets
@@ -13,19 +12,10 @@ table.Merge( _LAMBDAPLAYERSWEAPONS, {
         keepdistance = 800,
         attackrange = 5000,
 
-        clip = 1,
-
-        reloadtime = 3,
-        reloadanim = ACT_HL2MP_GESTURE_RELOAD_PISTOL,
-        reloadanimationspeed = 1,
-        reloadsounds = { },
-
-        callback = function( self, wepent, target )
-            if self.l_Clip <= 0 then self:ReloadWeapon() return end-- Just in case
-            
+        callback = function( self, wepent, target )            
             self.l_WeaponUseCooldown = CurTime() + 3
 
-            wepent:EmitSound( "weapons/rpg/rocketfire1.wav", 70, 100, 1, CHAN_WEAPON )
+            wepent:EmitSound( "Weapon_RPG.Single" )
 
             self:RemoveGesture( ACT_HL2MP_GESTURE_RANGE_ATTACK_RPG )
             self:AddGesture( ACT_HL2MP_GESTURE_RANGE_ATTACK_RPG )
@@ -44,7 +34,7 @@ table.Merge( _LAMBDAPLAYERSWEAPONS, {
                 end)
 
                 rocket:CallOnRemove( "lambdaplayer_rpgrocket_"..rocket:EntIndex(), function()
-                    rocket:StopSound( "weapons/rpg/rocket1.wav" )
+                    rocket:StopSound( "weapons/rpg/rocket1.wav" )--Trying to prevent source being dumb
                     util.BlastDamage( rocket, (self:IsValid()) and self or rocket, rocket:GetPos(), 260, 210)
                 end)
             end

--- a/lua/lambdaplayers/lambda/weapons/hl2_shotgun.lua
+++ b/lua/lambdaplayers/lambda/weapons/hl2_shotgun.lua
@@ -30,7 +30,7 @@ table.Merge( _LAMBDAPLAYERSWEAPONS, {
 
                 bullettbl.Num = 12
 
-                self.l_Clip = self.l_Clip - 0
+                self.l_Clip = self.l_Clip - 2
             else
                 self.l_WeaponUseCooldown = CurTime() + random(1, 1.25)
 
@@ -38,7 +38,7 @@ table.Merge( _LAMBDAPLAYERSWEAPONS, {
 
                 bullettbl.Num = 7
 
-                self.l_Clip = self.l_Clip - 0
+                self.l_Clip = self.l_Clip - 1
             end
             
             bullettbl.Attacker = self

--- a/lua/lambdaplayers/lambda/weapons/hl2_shotgun.lua
+++ b/lua/lambdaplayers/lambda/weapons/hl2_shotgun.lua
@@ -23,14 +23,14 @@ table.Merge( _LAMBDAPLAYERSWEAPONS, {
             if self.l_Clip <= 0 then self:ReloadWeapon() return end
 
             -- Special double shot
-            if math.random(6) == 1 and self.l_Clip >= 2 and self:GetRangeSquaredTo(target) <= (400 * 400) then
+            if random( 8 ) == 1 and self.l_Clip >= 2 and self:GetRangeSquaredTo(target) <= (400 * 400) then
                 self.l_WeaponUseCooldown = CurTime() + random(1.2, 1.5)
 
                 wepent:EmitSound( "Weapon_Shotgun.Double" )
 
                 bullettbl.Num = 12
 
-                self.l_Clip = self.l_Clip - 2
+                self.l_Clip = self.l_Clip - 0
             else
                 self.l_WeaponUseCooldown = CurTime() + random(1, 1.25)
 
@@ -38,7 +38,7 @@ table.Merge( _LAMBDAPLAYERSWEAPONS, {
 
                 bullettbl.Num = 7
 
-                self.l_Clip = self.l_Clip - 1
+                self.l_Clip = self.l_Clip - 0
             end
             
             bullettbl.Attacker = self
@@ -59,12 +59,9 @@ table.Merge( _LAMBDAPLAYERSWEAPONS, {
             wepent:FireBullets( bullettbl )
 
             -- To simulate pump action after the shot
-            self:SimpleTimer(0.5, function()
-                wepent:EmitSound( "Weapon_Shotgun.Special1" )
-                if bullettbl.Num == 12 then
-                    self:HandleShellEject( "ShotgunShellEject" )-- For the double shell secondary attack, not really important
-                end
-                self:HandleShellEject( "ShotgunShellEject" )
+            self:SimpleTimer(0.6, function()
+                wepent:EmitSound( "Weapon_Shotgun.Special1", 70, 100, 1, CHAN_WEAPON )
+                self:HandleShellEject( "ShotgunShellEject", Vector(0,12,0), Angle(-180,0,0) )
             end)
             
             return true

--- a/lua/lambdaplayers/lambda/weapons/hl2_smg1.lua
+++ b/lua/lambdaplayers/lambda/weapons/hl2_smg1.lua
@@ -19,6 +19,8 @@ table.Merge( _LAMBDAPLAYERSWEAPONS, {
         rateoffire = 0.07,
         muzzleflash = 1,
         shelleject = "ShellEject",
+        shelloffpos = Vector(3,5,5),
+        shelloffang = Angle(-180,0,0),
         attackanim = ACT_HL2MP_GESTURE_RANGE_ATTACK_SMG1,
         attacksnd = "Weapon_SMG1.Single",
 
@@ -29,7 +31,7 @@ table.Merge( _LAMBDAPLAYERSWEAPONS, {
 
         callback = function( self, wepent, target )
             -- Secondary grenade launcher
-            if random(75) == 1 and self:GetRangeSquaredTo(target) <= ( 1000 * 1000 ) then
+            if random( 75 ) == 1 and self:GetRangeSquaredTo(target) <= ( 1000 * 1000 ) then
                 local grenade = ents.Create( "grenade_ar2" )
                 if IsValid( grenade ) then
                     wepent:EmitSound( "Weapon_SMG1.Double" )

--- a/lua/lambdaplayers/lambda/weapons/hl2_stunstick.lua
+++ b/lua/lambdaplayers/lambda/weapons/hl2_stunstick.lua
@@ -35,7 +35,7 @@ table.Merge( _LAMBDAPLAYERSWEAPONS, {
         end,
         
         OnEquip = function( lambda, wepent )
-            wepent:EmitSound( "weapons/stunstick/spark"..random(2)..".wav", 70, random(98,102), 1, CHAN_WEAPON )
+            wepent:EmitSound( "Weapon_StunStick.Activate" )
         end,
         
         -- Emit sparks on hit

--- a/lua/lambdaplayers/lambda/weapons/hl2_usppistol.lua
+++ b/lua/lambdaplayers/lambda/weapons/hl2_usppistol.lua
@@ -16,13 +16,14 @@ table.Merge( _LAMBDAPLAYERSWEAPONS, {
         rateoffire = 0.2,
         muzzleflash = 1,
         shelleject = "ShellEject",
+        shelloffpos = Vector(0,2,5),
         attackanim = ACT_HL2MP_GESTURE_RANGE_ATTACK_PISTOL,
         attacksnd = "Weapon_Pistol.Single",
 
         reloadtime = 1.8,
         reloadanim = ACT_HL2MP_GESTURE_RELOAD_PISTOL,
         reloadanimationspeed = 1,
-        reloadsounds = { { 0, "weapons/pistol/pistol_reload1.wav" } },
+        reloadsounds = { { 0, "Weapon_Pistol.Reload" } },
 
         islethal = true,
     }

--- a/lua/lambdaplayers/lambda/weapons/holster.lua
+++ b/lua/lambdaplayers/lambda/weapons/holster.lua
@@ -54,6 +54,7 @@
     muzzleflash | Number | The muzzle flash type. 1 = Regular 5 = Combine 7 = Regular but bigger
     shelleject | String | Shell type valid types are ShellEject, RifleShellEject, ShotgunShellEject
     shelloffpos | Vector | 
+    shelloffang | Angle | 
             
 
     reloadtime | Number | The time it takes to reload

--- a/lua/lambdaplayers/lambda/weapons/misc_zombieclaws.lua
+++ b/lua/lambdaplayers/lambda/weapons/misc_zombieclaws.lua
@@ -49,22 +49,22 @@ table.Merge( _LAMBDAPLAYERSWEAPONS, {
             self:AddGesture( ACT_GMOD_GESTURE_RANGE_ZOMBIE )
             
             -- To make sure damage syncs with the animation
-            self:SimpleTimer(0.75, function()
-                if self:GetRangeSquaredTo(target) > (65 * 65) then wepent:EmitSound("npc/zombie/claw_miss"..random(2)..".wav", 70) return end
+            self:SimpleTimer( 0.75, function()
+                if self:GetRangeSquaredTo( target ) > (65 * 65) then wepent:EmitSound("npc/zombie/claw_miss"..random(2)..".wav", 70) return end
                 
-                local dmg = random(35,55)
+                local dmg = random( 35, 55 )
                 local dmginfo = DamageInfo()
-                dmginfo:SetDamage(dmg)
-                dmginfo:SetAttacker(self)
-                dmginfo:SetInflictor(wepent)
-                dmginfo:SetDamageType(DMG_SLASH)
+                dmginfo:SetDamage( dmg )
+                dmginfo:SetAttacker( self )
+                dmginfo:SetInflictor( wepent )
+                dmginfo:SetDamageType( DMG_SLASH )
                 dmginfo:SetDamageForce( ( target:WorldSpaceCenter() - self:WorldSpaceCenter() ):GetNormalized() * dmg )
                 
-                target:EmitSound("npc/zombie/claw_strike"..random(3)..".wav", 70)
+                target:EmitSound( "npc/zombie/claw_strike"..random(3)..".wav", 70)
                 
                 -- HP regen on attacks
                 if self:Health() < self:GetMaxHealth() * 2.25 and LambdaIsValid( target ) then
-                    self:SetHealth(math_min(self:Health() + self:GetMaxHealth() * Rand(0.10, 0.25), self:GetMaxHealth() * 2.25))
+                    self:SetHealth( math_min( self:Health() + self:GetMaxHealth() * Rand(0.10, 0.25), self:GetMaxHealth() * 2.25 ) )
                 end
                 
                 target:TakeDamageInfo( dmginfo )


### PR DESCRIPTION
Changes
- Added the shelloffpos and shelloffang to the HandleShellEject of DefaultRangedWeapon
- Checks for bulletcount, tracername because they were missing after last rewrite
- Check for reloadtime
- Check so that if there is no animation, it doesn't try to play one
- Fixed AR2 ball being infinite
- Replaced most full directories to soundscript names
- Cleaned up everything that wasn't required in the weapons anymore